### PR TITLE
Ensure links have protocol prefixes

### DIFF
--- a/slack-applybot/commands/uat_url.rb
+++ b/slack-applybot/commands/uat_url.rb
@@ -12,7 +12,7 @@ module SlackApplybot
         ingresses = Kubectl.uat_ingresses
         single_match = ingresses.find { |e| e.starts_with?(branch) }
         message_text = if single_match
-                         "Branch <#{single_match}|#{branch}> is available"
+                         "Branch <https://#{single_match}|#{branch}> is available"
                        else
                          "Sorry I can't find a branch for #{branch} I only have:\n#{display(ingresses)}"
                        end
@@ -24,7 +24,7 @@ module SlackApplybot
 
         def display(ingresses)
           ingresses.map do |ingress|
-            "<#{ingress}|#{ingress.gsub('-applyforlegalaid-uat', '').split('.').first}>"
+            "<https://#{ingress}|#{ingress.gsub('-applyforlegalaid-uat', '').split('.').first}>"
           end.join("\n")
         end
       end

--- a/spec/commands/uat_url_spec.rb
+++ b/spec/commands/uat_url_spec.rb
@@ -8,8 +8,8 @@ describe SlackApplybot::Commands::UatUrl, :vcr do
     let(:user_input) { "#{SlackRubyBot.config.user} uat urls" }
     let(:expected_response) do
       "Apply UAT urls:\n"\
-      "<ap-1234-test.fake.service.uk|ap-1234-test>\n"\
-      '<ap-4321-bad.fake.service.uk|ap-4321-bad>'
+      "<https://ap-1234-test.fake.service.uk|ap-1234-test>\n"\
+      '<https://ap-4321-bad.fake.service.uk|ap-4321-bad>'
     end
 
     it 'returns the expected message' do
@@ -23,7 +23,7 @@ describe SlackApplybot::Commands::UatUrl, :vcr do
     context 'that exists' do
       let(:branch) { 'ap-1234' }
       let(:expected_response) do
-        'Branch <ap-1234-test.fake.service.uk|ap-1234> is available'
+        'Branch <https://ap-1234-test.fake.service.uk|ap-1234> is available'
       end
 
       it 'returns the expected message' do
@@ -35,8 +35,8 @@ describe SlackApplybot::Commands::UatUrl, :vcr do
       let(:branch) { 'ap-666' }
       let(:expected_response) do
         "Sorry I can't find a branch for #{branch} I only have:\n"\
-        "<ap-1234-test.fake.service.uk|ap-1234-test>\n"\
-        '<ap-4321-bad.fake.service.uk|ap-4321-bad>'
+        "<https://ap-1234-test.fake.service.uk|ap-1234-test>\n"\
+        '<https://ap-4321-bad.fake.service.uk|ap-4321-bad>'
       end
 
       it 'returns the expected message' do


### PR DESCRIPTION
Slack prefixes it's own url when you don't provide an http or https.

If you try and show `example.com` slack will display `example.com` as a link but attempt to route you to `https://app.slack.com/client/CL13NTT0K3N/example.com` 😞 