### PR TITLE
Update cache to v2

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.6.x
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
This may speed up repository_dispatch jobs by reading
the cached bundler output