### PR TITLE
Update the invalid channel shared_example

### DIFF
--- a/spec/commands/details_spec.rb
+++ b/spec/commands/details_spec.rb
@@ -13,12 +13,11 @@ describe SlackApplybot::Commands::Details, :vcr do
       }
     }.to_json
   end
+  let(:app) { 'cfe' }
+  let(:env) { 'staging' }
+  let(:channel) { 'channel' }
 
   context 'when user requests details for a valid application and environment' do
-    let(:app) { 'cfe' }
-    let(:env) { 'staging' }
-    let(:channel) { 'channel' }
-
     let(:expected_response) do
       key = '`staging` details for `cfe`'
       build = 'app-bf400232676802bfcd7e53ff7ff013087ee6d1d1'

--- a/spec/commands/uat_url_spec.rb
+++ b/spec/commands/uat_url_spec.rb
@@ -35,9 +35,9 @@ describe SlackApplybot::Commands::UatUrl, :vcr do
   context 'when user requests a specific branch' do
     let(:user_input) { "#{SlackRubyBot.config.user} uat url #{branch}" }
     let(:channel) { 'channel' }
+    let(:branch) { 'ap-1234' }
 
     context 'that exists' do
-      let(:branch) { 'ap-1234' }
       let(:expected_response) do
         'Branch <https://ap-1234-test.fake.service.uk|ap-1234> is available'
       end

--- a/spec/support/shared_examples/invalid_channel.rb
+++ b/spec/support/shared_examples/invalid_channel.rb
@@ -1,5 +1,4 @@
 RSpec.shared_examples 'the channel is invalid' do
-  let(:user_input) { "#{SlackRubyBot.config.user} 2fa-start" }
   let!(:client) { SlackRubyBot::App.new.send(:client) }
   let(:message_hook) { SlackRubyBot::Hooks::Message.new }
   let(:params) { Hashie::Mash.new(text: user_input, channel: channel, user: 'user') }


### PR DESCRIPTION
It was always passing the same command.  Removing that line
ensures that each command is tested.

Updated two tests to ensure the correct variables are available
for the command to run in the shared example