### PR TITLE
Add FFI gem

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -29,6 +29,10 @@ jobs:
   rspec:
     runs-on: ubuntu-latest
     steps:
+      - name: Install libffi6
+        run: |
+          wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
+          sudo apt install ./libffi6_3.2.1-8_amd64.deb
       - uses: actions/checkout@v2
       - name: Set up Ruby 2.7
         uses: actions/setup-ruby@v1


### PR DESCRIPTION
Github seems to have changed the packages included on the default image 🤔 
For now - 🤞 - we need to manually add it to the rspec (and maybe more) steps.